### PR TITLE
bump Netty to 4.1.0-CR4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.0.Beta7</version>
+            <version>4.1.0.CR4</version>
         </dependency>
         <!-- Test Deps -->
         <dependency>


### PR DESCRIPTION
Bump Netty dep to 4.1.0-RC4 because beta7 is ancient.

Tests pass
